### PR TITLE
Add me and ls cli commands

### DIFF
--- a/src/linear/console.py
+++ b/src/linear/console.py
@@ -23,6 +23,15 @@ class DataclassJsonEncoder(json.JSONEncoder):
         return super().default(o)
 
 
+def print_me(me, issues: list[Issue], format):
+    if format == "json":
+        print(json.dumps(issues, cls=DataclassJsonEncoder))
+        return
+    if format == "markdown":
+        print(me_markdown(me, issues))
+        return
+
+
 def print_issues(
     issues: list[Issue],
     format: Literal[
@@ -62,6 +71,23 @@ def print_issue(
 
 def issue_markdown(issue: Issue):
     return issue_text(issue)
+
+
+def me_markdown(_, issues: list[Issue]):
+    text = ""
+
+    for issue in issues:
+        text += title_text(issue)
+        text += description_text(issue.description)
+
+        # Sort the sub_issues by state
+        sub_issues = sorted(issue.children, key=lambda x: x.state.name)
+
+        for subissue in sub_issues:
+            text += f"  {title_text(subissue)}"
+            text += description_text(subissue.description)
+
+    print(text, end="")
 
 
 def issues_markdown(issues: list[Issue]):
@@ -122,13 +148,19 @@ def title_text(issue: Issue):
     return f"{title}\n"
 
 
+def description_text(description: str):
+    if not description:
+        return ""
+    description = description.replace("\n\\", "\n")
+    formatted_description = highlight.markdown(description)
+    return f"\n{formatted_description}"
+
+
 def issue_text(issue: Issue):
     text = title_text(issue)
 
     if issue.description:
-        description = issue.description.replace("\n\\", "\n")
-        formatted_description = highlight.markdown(description)
-        text += f"\n{formatted_description}"
+        text += description_text(issue.description)
 
     if show_subissues := issue.children:
         text += "Sub-issues:\n"

--- a/src/linear_cli.py
+++ b/src/linear_cli.py
@@ -141,6 +141,33 @@ def cmd_me(state: str, json: bool):
     console.print_me(me, issues, format)
 
 
+@click.command("ls")
+@click.option("--state", type=click.Choice(ISSUE_STATES), default=None)
+@click.option("--json", is_flag=True)
+def cmd_ls(state: str, json: bool):
+    """
+    List linear issues assigned to you
+    """
+    issue_states = [state] if state else ["backlog", "started", "unstarted"]
+    me = get_me()
+
+    if me.assigned_issues is None:
+        # print("No issues assigned to you")
+        return
+
+    issues = sorted(
+        [
+            # I need to fetch the issue to be able to load sub issues
+            get_issue(issue.id)
+            for issue in me.assigned_issues
+            if issue.state.type in issue_states
+        ],
+        key=lambda issue: issue.state.name,
+    )
+    format = "json" if json else "markdown"
+    console.print_issues(issues, format)
+
+
 @click.group()
 def cli():
     setup_logging()
@@ -149,5 +176,6 @@ def cli():
 cli.add_command(cmd_issue)
 cli.add_command(cmd_team)
 cli.add_command(cmd_me)
+cli.add_command(cmd_ls)
 if __name__ == "__main__":
     cli()

--- a/src/linear_cli.py
+++ b/src/linear_cli.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from linear import print
+from linear import console
 from linear.client import get_me, get_team, get_issue, ISSUE_STATES
 
 LINEAR_API_KEY = os.environ["LINEAR_API_KEY"]
@@ -33,14 +33,6 @@ def cmd_team(state: Optional[str], json: bool, table: bool):
     linear team
     """
     me = get_me()
-    printer = None
-    if json:
-        printer = print.JsonPrinter(sys.stdout)
-    elif table:
-        printer = print.TablePrinter()
-    else:
-        printer = print.ConsolePrinter()
-
     if not me.teams:
         LOGGER.error("You are not a member of any teams")
         sys.exit(1)
@@ -53,8 +45,8 @@ def cmd_team(state: Optional[str], json: bool, table: bool):
             [issue for issue in team_issues if issue.state.type in issue_states],
             key=lambda issue: issue.state.name,
         )
-
-        printer.print_issue_list(issues)
+        format = "json" if json else "table" if table else "markdown"
+        console.print_issues(issues, format)
 
 
 @click.group("issue")
@@ -87,13 +79,8 @@ def cmd_issue_list(state: str, json: bool):
         ],
         key=lambda issue: issue.state.name,
     )
-
-    printer = None
-    if json:
-        printer = print.JsonPrinter(sys.stdout)
-    else:
-        printer = print.ConsolePrinter()
-    printer.print_issue_list(issues)
+    format = "json" if json else "markdown"
+    console.print_issues(issues, format)
 
 
 @cmd_issue.command("view")
@@ -123,13 +110,8 @@ def cmd_issue_view(issue_id: str, web: bool, json: bool):
         webbrowser.open(issue.url)
         return
 
-    printer = None
-    if json:
-        printer = print.JsonPrinter(sys.stdout)
-    else:
-        printer = print.ConsolePrinter()
-
-    printer.print_issue(issue)
+    format = "json" if json else "markdown"
+    console.print_issue(issue, format)
 
 
 @click.group()

--- a/src/linear_cli.py
+++ b/src/linear_cli.py
@@ -114,6 +114,33 @@ def cmd_issue_view(issue_id: str, web: bool, json: bool):
     console.print_issue(issue, format)
 
 
+@click.command("me")
+@click.option("--json", is_flag=True)
+@click.option("--state", type=click.Choice(ISSUE_STATES), default=None)
+def cmd_me(state: str, json: bool):
+    """
+    List linear issues assigned to you
+    """
+    issue_states = [state] if state else ["backlog", "started", "unstarted"]
+    me = get_me()
+
+    if me.assigned_issues is None:
+        # print("No issues assigned to you")
+        return
+
+    issues = sorted(
+        [
+            # I need to fetch the issue to be able to load sub issues
+            get_issue(issue.id)
+            for issue in me.assigned_issues
+            if issue.state.type in issue_states
+        ],
+        key=lambda issue: issue.state.name,
+    )
+    format = "json" if json else "markdown"
+    console.print_me(me, issues, format)
+
+
 @click.group()
 def cli():
     setup_logging()
@@ -121,5 +148,6 @@ def cli():
 
 cli.add_command(cmd_issue)
 cli.add_command(cmd_team)
+cli.add_command(cmd_me)
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Add new cli commands `me` and `ls`.

me: Detailed list of issues assigned to the user.
ls: List of issues assigned to the user. Same as `li issue list`.

Also rename and refactor print module to console.

Usage:
```sh
linear me --json
linear me --state started
linear_cli ls --state started --json
```